### PR TITLE
Changed  the docker image labels and name

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -11,11 +11,12 @@ pipeline {
     }
 
     environment {
-        NAME = "cray-hms-hmnfd"
+        NAME = "cray-hmnfd"
         DESCRIPTION = "Cray State Change Notification Fanout Service"
         IS_STABLE = getBuildIsStable()
         VERSION = getDockerBuildVersion(isStable: env.IS_STABLE)
-        DOCKER_ARGS = getDockerBuildArgs(name: env.NAME, description: env.DESCRIPTION, version: env.VERSION)
+        DOCKER_ARGS = getDockerBuildArgs(name: "hms-hmnfd", description: env.DESCRIPTION, version: env.VERSION)
+        CHART_NAME = "cray-hms-hmnfd"
         CHART_VERSION = getChartVersion(version: env.VERSION)
     }
 
@@ -48,7 +49,7 @@ pipeline {
             steps {
                 script {
                     publishCsmDockerImage(image: env.NAME, tag: env.VERSION, isStable: env.IS_STABLE)
-                    publishCsmHelmCharts(component: env.NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
+                    publishCsmHelmCharts(component: env.CHART_NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
                 }
             }
         }

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 #
 # (MIT License)
 
+NAME ?= cray-hmnfd
 VERSION ?= $(shell cat .version)
 DOCKER_IMAGE ?= ${NAME}:${VERSION}
 


### PR DESCRIPTION
This is a PR to the branch "feature/github". Are these changes right?

image name: cray-hmnfd
image name label: hms-hmnfd
image version label: 1.9.1...

This was gleaned from the following log statements in this old build:
https://cje2.dev.cray.com/teams-hms-team/job/hms-team/job/hms-hmi-nfd/job/master/158/consoleText

```
[2021-07-14T14:59:20.709Z] LABEL org.label-schema.name="hms-hmnfd"       org.label-schema.description="Cray State Change Notification Fanout Service"       org.label-schema.url="http://www.cray.com/"       org.label-schema.vcs-url="https://stash.us.cray.com/scm/HMS/hms-hmi-nfd.git"       org.label-schema.vendor="Cray Inc"       org.label-schema.version="1.9.1-20210714144423_b84029c"       org.label-schema.schema-version="1.0"
[2021-07-14T14:59:20.709Z] + '[' master == master ']'
[2021-07-14T14:59:20.709Z] + docker build --no-cache --pull --tag arti.dev.cray.com/csm-docker-master-local/cray-hmnfd:1.9.1-20210714144423_b84029c -f Dockerfile.labeled . --label com.jfrog.artifactory.retention.maxCount=10
```

The helm package name was right as: cray-hms-hmnfd

`[2021-07-14T15:12:22.735Z] + docker run --rm -v /root/****-azure/312efd5f/workspace/hms-team_hms-hmi-nfd_master/kubernetes:/charts arti.dev.cray.com/internal-docker-master-local/cray-chartsutil:latest helm package /charts/cray-hms-hmnfd -d /charts/.packaged --app-version 1.9.1-20210714144423_b84029c --version 1.9.1-20210714144423+b84029c`
